### PR TITLE
cmd_vel and odom integration for the sensorless jetbot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   sensor_msgs
+  controller_manager  
 )
 
 ## System dependencies are found with CMake's conventions
@@ -118,7 +119,7 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(
-# include
+  include
   ${catkin_INCLUDE_DIRS}
   ${CUDA_INCLUDE_DIRS}
 )
@@ -129,6 +130,10 @@ include_directories(/usr/include/gstreamer-1.0 /usr/include/glib-2.0 /usr/includ
 # camera node
 add_executable(jetbot_camera src/jetbot_camera.cpp src/image_converter.cpp)
 target_link_libraries(jetbot_camera ${catkin_LIBRARIES} jetson-utils)
+
+# motor controller
+add_executable(jetbot_controller src/motor2927_controller.cpp src/adafruitmotorhat.cpp src/adafruitdcmotor.cpp src/pwm.cpp)
+target_link_libraries(jetbot_controller ${catkin_LIBRARIES})
 
 ## Declare a C++ library
 # add_library(${PROJECT_NAME}

--- a/config/diff_drive.yaml
+++ b/config/diff_drive.yaml
@@ -1,0 +1,50 @@
+mobile_base_controller:
+  type        : "diff_drive_controller/DiffDriveController"
+  left_wheel  : 'robot_left_wheel_hinge'
+  right_wheel : 'robot_right_wheel_hinge'
+  publish_rate: 50.0               # default: 50
+  pose_covariance_diagonal : [0.001, .001, 1000000., 1000000., 1000000., 1000.]
+  twist_covariance_diagonal: [0.001, .001, 1000000., 1000000., 1000000., 1000.]
+ 
+  # Wheel separation and diameter. These are both optional.
+  # diff_drive_controller will attempt to read either one or both from the
+  # URDF if not specified as a parameter
+  wheel_separation : 0.1025
+  wheel_radius : 0.03
+ 
+  # Wheel separation and radius multipliers
+  wheel_separation_multiplier: 4.0 # default: 1.0
+  wheel_radius_multiplier    : 0.075 # default: 1.0
+
+  # Odometry to commands calibration, used for dead reckoning
+  v_multiplier : 0.0125
+  w_multiplier : 0.05
+ 
+  # Velocity commands timeout [s], default 0.5
+  cmd_vel_timeout: 0.25
+
+  enable_odom_tf: true
+ 
+  # Base frame_id
+  base_frame_id: robot__chassis #default: base_link
+ 
+  # Velocity and acceleration limits
+  # Whenever a min_* is unspecified, default to -max_*
+  linear:
+    x:
+      has_velocity_limits    : true
+      max_velocity           : 0.5  # m/s
+      min_velocity           : -0.5 # m/s
+      has_acceleration_limits: true
+      max_acceleration       : 1.0  # m/s^2
+      min_acceleration       : -1.0 # m/s^2
+      has_jerk_limits        : true
+      max_jerk               : 5.0  # m/s^3
+  angular:
+    z:
+      has_velocity_limits    : true
+      max_velocity           : 1.7  # rad/s
+      has_acceleration_limits: true
+      max_acceleration       : 1.5  # rad/s^2
+      has_jerk_limits        : true
+      max_jerk               : 2.5  # rad/s^3

--- a/launch/jetbot.launch
+++ b/launch/jetbot.launch
@@ -1,0 +1,31 @@
+<launch>
+
+  <arg name="model" default="$(find jetbot_ros)/model/jetbot.urdf"/>
+  <arg name="gui" default="true"/>
+  <arg name="rvizconfig" default="$(find jetbot_ros)/rviz/urdf.rviz" />
+
+  <node pkg="tf2_ros" type="static_transform_publisher" name="laserlink_broadcaster" args="0.05 0 0.03 0 0 0 robot__chassis base_laser" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="chassis_broadcaster" args="0 0 0 0 0 0 base_link robot__chassis" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="odom_broadcaster" args="0 0 0 0 0 0 odom map" /> 
+
+  <param name="robot_description" command="$(find xacro)/xacro.py $(arg model)"/>
+  <param name="use_gui" value="gui"/>
+  
+  <node name="laser_node" pkg="urg_node" type="urg_node" >
+    <param name="serial_port" value="/dev/ttyACM0"/>
+    <param name="frame_id" value="base_laser"/>
+  </node>
+  
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <!-- <node name="rviz" pkg="rviz" type="rviz" args="-d $(arg rvizconfig)" required="true" /> -->
+
+  <!-- <node name="map_server" pkg="map_server" type="map_server" args="$(find jetbot_ros)/map/test_map.yaml"/> -->
+  <!-- <node pkg="tf2_ros" type="static_transform_publisher" name="map_base_broadcaster" args="0 0 0 0 0 0 map base_link" /> -->
+  
+  <node name="motor_controller" pkg="jetbot_ros" type="jetbot_controller" output="screen"/> <!--output="screen"/> -->
+
+  <rosparam file="$(find jetbot_ros)/config/diff_drive.yaml" command="load" />
+  <node name="jetbot_controller_manager" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="mobile_base_controller"/>
+  
+</launch>

--- a/model/jetbot.urdf
+++ b/model/jetbot.urdf
@@ -1,0 +1,94 @@
+<?xml version="1.0" ?>
+<robot name="robot">
+  <joint name="robot_left_wheel_hinge" type="continuous">
+    <parent link="robot__chassis"/>
+    <child link="robot__left_wheel"/>
+    <origin rpy="0       0       1.57079" xyz="0.03     0.05125  0.03"/>
+    <axis xyz="1  0  0"/>
+    <limit effort="0" lower="0" upper="0" velocity="0"/>
+  </joint>
+  <joint name="robot_right_wheel_hinge" type="continuous">
+    <parent link="robot__chassis"/>
+    <child link="robot__right_wheel"/>
+    <origin rpy="0       0       1.57079" xyz="0.03   -0.0595  0.03"/>
+    <axis xyz="1  0  0"/>
+    <limit effort="0" lower="0" upper="0" velocity="0"/>
+  </joint>
+  <joint name="robot__camera_joint" type="fixed">
+    <parent link="robot__chassis"/>
+    <child link="robot__camera_link"/>
+    <origin rpy="0    0.25  0" xyz="0.055   0      0.0857"/>
+    <axis xyz="0.96891  0       0.2474"/>
+    <limit effort="0" lower="0" upper="0" velocity="0"/>
+  </joint>
+  <link name="robot__chassis">
+    <inertial>
+      <mass value="0"/>
+      <origin rpy="0  0  0" xyz="0  0  0"/>
+      <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+    </inertial>
+    <collision name="robot__collision">
+      <origin rpy="1.57079  0       1.57079" xyz="0     0     0.043"/>
+      <geometry>
+        <mesh filename="package://jetbot_ros/gazebo/jetbot/meshes/JetBot-v3-Chassis.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+    <visual name="robot__visual">
+      <origin rpy="1.57079  0       1.57079" xyz="0     0     0.043"/>
+      <geometry>
+        <mesh filename="package://jetbot_ros/gazebo/jetbot/meshes/JetBot-v3-Chassis.dae" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </visual>
+  </link>
+  <link name="robot__left_wheel">
+    <inertial>
+      <mass value="0"/>
+      <origin rpy="0  0  0" xyz="0  0  0"/>
+      <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+    </inertial>
+    <collision name="robot__collision">
+      <origin rpy="0  0  0" xyz="0  0  0"/>
+      <geometry>
+        <mesh filename="package://jetbot_ros/gazebo/jetbot/meshes/JetBot-v3-Wheel.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+    <visual name="robot__visual">
+      <origin rpy="0  0  0" xyz="0  0  0"/>
+      <geometry>
+        <mesh filename="package://jetbot_ros/gazebo/jetbot/meshes/JetBot-v3-Wheel.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </visual>
+  </link>
+  <link name="robot__right_wheel">
+    <inertial>
+      <mass value="0"/>
+      <origin rpy="0  0  0" xyz="0  0  0"/>
+      <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+    </inertial>
+    <collision name="robot__collision">
+      <origin rpy="0  0  0" xyz="0  0  0"/>
+      <geometry>
+        <mesh filename="package://jetbot_ros/gazebo/jetbot/meshes/JetBot-v3-Wheel.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+    <visual name="robot__visual">
+      <origin rpy="0  0  0" xyz="0  0  0"/>
+      <geometry>
+        <mesh filename="package://jetbot_ros/gazebo/jetbot/meshes/JetBot-v3-Wheel.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </visual>
+  </link>
+  <link name="robot__camera_link">
+    <inertial>
+      <mass value="0.1"/>
+      <origin rpy="0  0  0" xyz="0  0  0"/>
+      <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+    </inertial>
+    <visual name="robot__visual">
+      <origin rpy="0  0  0" xyz="0  0  0"/>
+      <geometry>
+        <box size="0.001 0.001 0.001"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/src/adafruitdcmotor.cpp
+++ b/src/adafruitdcmotor.cpp
@@ -1,0 +1,99 @@
+/**
+ *  adafruitdcmotor.cpp
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2018, Tom Clarke
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+#include "adafruitdcmotor.h"
+
+#include <iostream>
+#include <algorithm>
+
+AdafruitDCMotor::AdafruitDCMotor (PWM& pwm, int index)
+    : controller (pwm)
+{
+    switch (index)
+    {
+        case 0:
+            pwmPin = 8;
+            in2Pin = 9;
+            in1Pin = 10;
+            break;
+        case 1:
+            pwmPin = 13;
+            in2Pin = 12;
+            in1Pin = 11;
+            break;
+        case 2:
+            pwmPin = 2;
+            in2Pin = 3;
+            in1Pin = 4;
+            break;
+        case 3:
+            pwmPin = 7;
+            in2Pin = 6;
+            in1Pin = 5;
+            break;
+        default:
+            std::cerr << "Motor index out-of-range. Must be between 1 and 4 inclusive." << std::endl;
+            break;
+    }
+}
+
+void AdafruitDCMotor::run (Command command)
+{
+    switch (command)
+    {
+        case kForward:
+            setPin (in1Pin, true);
+            setPin (in2Pin, false);
+            break;
+        case kBackward:
+            setPin (in1Pin, false);
+            setPin (in2Pin, true);
+            break;
+        case kRelease:
+            setPin (in1Pin, false);
+            setPin (in2Pin, false);
+            break;
+        default:
+            break;
+    }
+}
+
+void AdafruitDCMotor::setSpeed (int speed)
+{
+    speed = std::max (0, std::min (speed, 255));
+    controller.setChannel (pwmPin, 0, speed * 16);
+}
+
+void AdafruitDCMotor::setPin (int pin, bool enabled)
+{
+    if (pin < 0 || pin > 15)
+    {
+        std::cerr << "Failed to set PWM pin " << pin << ". Must be between 0 and 15 inclusive." << std::endl;
+        return;
+    }
+
+    controller.setChannel (pin, enabled ? 4096 : 0, enabled ? 0 : 4096);
+}

--- a/src/adafruitdcmotor.h
+++ b/src/adafruitdcmotor.h
@@ -1,0 +1,59 @@
+/**
+ *  adafruitdcmotor.h
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2018, Tom Clarke
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+#pragma once
+
+#include "pwm.h"
+
+class AdafruitDCMotor
+{
+public:
+    enum Command
+    {
+        kForward = 1,
+        kBackward = 2,
+        kBrake = 3,
+        kRelease = 4,
+    };
+
+    AdafruitDCMotor (PWM& pwm, int index);
+
+    /** Makes the motor perform an action.
+     *  @see Commands
+     */
+    void run (Command command);
+
+    /** Sets the speed of the motor.
+     *  Expects a value between 0 and 255 inclusive.
+     */
+    void setSpeed (int speed);
+
+private:
+    void setPin (int pin, bool enabled);
+
+    PWM& controller;
+    int pwmPin = 0, in1Pin = 0, in2Pin = 0;
+};

--- a/src/adafruitmotorhat.cpp
+++ b/src/adafruitmotorhat.cpp
@@ -1,0 +1,48 @@
+/**
+ *  adafruitmotorhat.cpp
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2018, Tom Clarke
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+#include "adafruitmotorhat.h"
+
+AdafruitMotorHAT::AdafruitMotorHAT (int bus, char address)
+    : controller (bus, address)
+{
+    // add the dc motors
+    for (int i = 0; i < 4; ++i)
+    {
+        dcMotors.push_back (std::make_shared<AdafruitDCMotor> (controller, i));
+    }
+
+    // set the frequency
+    controller.setFrequency (frequency);
+}
+
+std::shared_ptr<AdafruitDCMotor> AdafruitMotorHAT::getMotor (unsigned int number)
+{
+    if (number > 0 && number <= dcMotors.size())
+        return std::shared_ptr<AdafruitDCMotor> (dcMotors[number - 1]);
+    else
+        return std::shared_ptr<AdafruitDCMotor>();
+}

--- a/src/adafruitmotorhat.h
+++ b/src/adafruitmotorhat.h
@@ -1,0 +1,51 @@
+/**
+ *  adafruitmotorhat.h
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2018, Tom Clarke
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+#pragma once
+
+#include "pwm.h"
+#include "adafruitdcmotor.h"
+
+#include <memory>
+#include <vector>
+
+class AdafruitMotorHAT
+{
+public:
+    AdafruitMotorHAT (int bus = 1, char address = 0x60);
+
+    /** Get one of the DC motors controlled by the HAT.
+     *  Expects a value between 1 and 4 inclusive.
+     *  If the number is out-of-range, the shared pointer
+     *  returned from the method will be empty.
+     */
+    std::shared_ptr<AdafruitDCMotor> getMotor (unsigned int number);
+
+private:
+    PWM controller;
+    int frequency = 1600;
+    std::vector<std::shared_ptr<AdafruitDCMotor>> dcMotors;
+};

--- a/src/i2cdevice_wrapper.h
+++ b/src/i2cdevice_wrapper.h
@@ -1,0 +1,108 @@
+/**
+ *  i2cdevice_wrapper.h
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2018, Gavin Kane
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+#pragma once
+
+#include "linux/i2c-dev.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <cstring>
+#include <unistd.h>
+#include "ros/ros.h"
+
+class i2cdevice_wrapper
+{
+public:
+    i2cdevice_wrapper (int bus, char addr)
+    {
+	this->bus = bus;
+	this->addr = addr;
+	char filename[20];
+	snprintf(filename, 19, "/dev/i2c-%d", this->bus);
+	this->file = open(filename, O_RDWR);
+	if (this->file < 0) {
+		ROS_INFO("Oh dear, something went wrong with open()! %s\n", std::strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	this->addr = addr;
+
+	if (ioctl(this->file, I2C_SLAVE, this->addr) < 0) {
+		ROS_INFO("Oh dear, something went wrong with ioctl()! %s\n", std::strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+        valid = true;
+    };
+
+    /** 
+     */
+    void write8 (char reg, char value)
+    {
+	// Using SMBus commands
+	const __s32 result = i2c_smbus_write_byte_data(this->file, reg, value);
+	if (result < 0) {
+		// ERROR HANDLING: i2c transaction failed
+		ROS_INFO("Oh dear, something went wrong with i2c_smbus_write_byte_data()>i2c_smbus_access()>ioctl()! %s\n", strerror(errno));
+		this->valid = false;
+		exit(EXIT_FAILURE);
+	} else {
+		// res contains the read word
+		//printf("0x%02x\n", result);
+	}
+    }
+
+    /** 
+     */
+    int read8 (char reg)
+    {
+	// Using SMBus commands
+	const __s32 result = i2c_smbus_read_byte_data(this->file, reg);
+	if (result < 0) {
+		// ERROR HANDLING: i2c transaction failed
+		ROS_INFO("Oh dear, something went wrong with i2c_smbus_read_byte_data()>i2c_smbus_access()>ioctl()! %s\n", strerror(errno));
+		this->valid = false;
+		exit(EXIT_FAILURE);
+	} else {
+		// res contains the read word
+		//printf("0x%02x\n", result);
+	}
+   };
+   bool isValid()
+   {
+	return valid;
+   };
+   ~i2cdevice_wrapper()
+   {
+	close(file);
+   };
+private:
+   int bus = 1;
+   char addr = 0x60;
+   int file;
+   bool valid = false;
+};

--- a/src/jetbotHardwareInt.h
+++ b/src/jetbotHardwareInt.h
@@ -1,0 +1,150 @@
+/**
+ *  jetbotHardwareInt.h
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2018, Gavin Kane
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+#include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/joint_state_interface.h>
+#include <hardware_interface/robot_hw.h>
+#include "adafruitmotorhat.h"
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+#include <time.h>
+
+
+class jetbotHardwareInt : public hardware_interface::RobotHW
+{
+public:
+  jetbotHardwareInt() {
+
+
+   // connect and register the joint state interface
+   hardware_interface::JointStateHandle state_handle_left("robot_left_wheel_hinge", &pos[0], &vel[0], &eff[0]);
+   jnt_state_interface.registerHandle(state_handle_left);
+
+   hardware_interface::JointStateHandle state_handle_right("robot_right_wheel_hinge", &pos[1], &vel[1], &eff[1]);
+   jnt_state_interface.registerHandle(state_handle_right);
+
+   registerInterface(&jnt_state_interface);
+
+   // connect and register the joint position interface
+   hardware_interface::JointHandle vel_handle_left(jnt_state_interface.getHandle("robot_left_wheel_hinge"), &cmd[0]);
+   jnt_vel_interface.registerHandle(vel_handle_left);
+
+   hardware_interface::JointHandle vel_handle_right(jnt_state_interface.getHandle("robot_right_wheel_hinge"), &cmd[1]);
+   jnt_vel_interface.registerHandle(vel_handle_right);
+
+   registerInterface(&jnt_vel_interface);
+   if (ros::param::get("/mobile_base_controller/v_multiplier", v_multiplier))
+   {
+	ROS_INFO("v_multiplier found: %f", v_multiplier);
+   }
+   if (ros::param::get("/mobile_base_controller/w_multiplier", w_multiplier))
+   {
+	ROS_INFO("w_multiplier found: %f", w_multiplier);
+   }
+  }
+
+  void write() {
+	  gettimeofday(&tv, NULL);
+	  long long u_seconds = tv.tv_sec*1000000LL + tv.tv_usec;
+          long diff = u_seconds - last_u_seconds;
+	  last_u_seconds = u_seconds;
+          //ROS_INFO("update rate %d us", diff);
+	  //ROS_INFO("update motors %f %f", cmd[0], cmd[1]);
+	  if (cmd[0] > 0)
+	  {
+	  	  motorDriver.getMotor(motor_left_ID)->run(AdafruitDCMotor::Command::kForward);
+	  	  motorDriver.getMotor(motor_left_ID)->setSpeed(cmd[0]);
+	  }
+	  else
+	  {
+	  	  motorDriver.getMotor(motor_left_ID)->run(AdafruitDCMotor::Command::kBackward);
+	  	  motorDriver.getMotor(motor_left_ID)->setSpeed(-cmd[0]);
+	  }
+
+	  if (cmd[1] > 0)
+	  {
+	  	  motorDriver.getMotor(motor_right_ID)->run(AdafruitDCMotor::Command::kForward);
+	  	  motorDriver.getMotor(motor_right_ID)->setSpeed(cmd[1]);
+	  }
+	  else
+	  {
+	  	  motorDriver.getMotor(motor_right_ID)->run(AdafruitDCMotor::Command::kBackward);
+	  	  motorDriver.getMotor(motor_right_ID)->setSpeed(-cmd[1]);
+	  }
+  }
+
+  void read() {
+		// Read odometry from extern interface
+
+		// No external sensor exists
+		// Use basic dead reconing with movement model
+
+		// Motor has deadzone < 44.
+		// This needs to be modified to include a hysterisis.
+		// If motor is already turning, can maintain down to....
+		// Scaling is also incorrect at present!!
+		if (abs(cmd[0]) < 44)		
+			temp_cmd[0] = 0;
+		else 
+			temp_cmd[0] = cmd[0];
+		if (abs(cmd[1]) < 44)		
+			temp_cmd[1] = 0;
+		else 
+			temp_cmd[1] = cmd[1];
+
+		mean_v = (temp_cmd[0] + temp_cmd[1])/2;
+		mean_w = (temp_cmd[0] - temp_cmd[1])/2;
+		mean_v = mean_v * v_multiplier;
+		mean_w = mean_w * w_multiplier;
+		
+
+		pos[0] += mean_v+mean_w;
+
+		pos[1] += mean_v-mean_w;
+  }
+
+private:
+  hardware_interface::JointStateInterface jnt_state_interface;
+  hardware_interface::VelocityJointInterface jnt_vel_interface;
+  double cmd[2];
+  double pos[2];
+  double vel[2];
+  double eff[2];
+  ros::NodeHandle nh;
+  double mean_v;
+  double mean_w;
+  double temp_cmd[2];
+  double v_multiplier = 0.0125;  
+  double w_multiplier = 0.125;
+  AdafruitMotorHAT motorDriver;
+  int motor_left_ID = 1;
+  int motor_right_ID = 2;
+
+
+  struct timeval  tv;
+  long long last_u_seconds;
+};

--- a/src/linux/i2c-dev.h
+++ b/src/linux/i2c-dev.h
@@ -1,0 +1,330 @@
+/*
+    i2c-dev.h - i2c-bus driver, char device interface
+
+    Copyright (C) 1995-97 Simon G. Vogl
+    Copyright (C) 1998-99 Frodo Looijaard <frodol@dds.nl>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA 02110-1301 USA.
+*/
+
+#ifndef _LINUX_I2C_DEV_H
+#define _LINUX_I2C_DEV_H
+
+#include <linux/types.h>
+#include <sys/ioctl.h>
+#include <stddef.h>
+
+
+/* -- i2c.h -- */
+
+
+/*
+ * I2C Message - used for pure i2c transaction, also from /dev interface
+ */
+struct i2c_msg {
+	__u16 addr;	/* slave address			*/
+	unsigned short flags;
+#define I2C_M_TEN	0x10	/* we have a ten bit chip address	*/
+#define I2C_M_RD	0x01
+#define I2C_M_NOSTART	0x4000
+#define I2C_M_REV_DIR_ADDR	0x2000
+#define I2C_M_IGNORE_NAK	0x1000
+#define I2C_M_NO_RD_ACK		0x0800
+	short len;		/* msg length				*/
+	char *buf;		/* pointer to msg data			*/
+};
+
+/* To determine what functionality is present */
+
+#define I2C_FUNC_I2C			0x00000001
+#define I2C_FUNC_10BIT_ADDR		0x00000002
+#define I2C_FUNC_PROTOCOL_MANGLING	0x00000004 /* I2C_M_{REV_DIR_ADDR,NOSTART,..} */
+#define I2C_FUNC_SMBUS_PEC		0x00000008
+#define I2C_FUNC_SMBUS_BLOCK_PROC_CALL	0x00008000 /* SMBus 2.0 */
+#define I2C_FUNC_SMBUS_QUICK		0x00010000
+#define I2C_FUNC_SMBUS_READ_BYTE	0x00020000
+#define I2C_FUNC_SMBUS_WRITE_BYTE	0x00040000
+#define I2C_FUNC_SMBUS_READ_BYTE_DATA	0x00080000
+#define I2C_FUNC_SMBUS_WRITE_BYTE_DATA	0x00100000
+#define I2C_FUNC_SMBUS_READ_WORD_DATA	0x00200000
+#define I2C_FUNC_SMBUS_WRITE_WORD_DATA	0x00400000
+#define I2C_FUNC_SMBUS_PROC_CALL	0x00800000
+#define I2C_FUNC_SMBUS_READ_BLOCK_DATA	0x01000000
+#define I2C_FUNC_SMBUS_WRITE_BLOCK_DATA 0x02000000
+#define I2C_FUNC_SMBUS_READ_I2C_BLOCK	0x04000000 /* I2C-like block xfer  */
+#define I2C_FUNC_SMBUS_WRITE_I2C_BLOCK	0x08000000 /* w/ 1-byte reg. addr. */
+
+#define I2C_FUNC_SMBUS_BYTE (I2C_FUNC_SMBUS_READ_BYTE | \
+                             I2C_FUNC_SMBUS_WRITE_BYTE)
+#define I2C_FUNC_SMBUS_BYTE_DATA (I2C_FUNC_SMBUS_READ_BYTE_DATA | \
+                                  I2C_FUNC_SMBUS_WRITE_BYTE_DATA)
+#define I2C_FUNC_SMBUS_WORD_DATA (I2C_FUNC_SMBUS_READ_WORD_DATA | \
+                                  I2C_FUNC_SMBUS_WRITE_WORD_DATA)
+#define I2C_FUNC_SMBUS_BLOCK_DATA (I2C_FUNC_SMBUS_READ_BLOCK_DATA | \
+                                   I2C_FUNC_SMBUS_WRITE_BLOCK_DATA)
+#define I2C_FUNC_SMBUS_I2C_BLOCK (I2C_FUNC_SMBUS_READ_I2C_BLOCK | \
+                                  I2C_FUNC_SMBUS_WRITE_I2C_BLOCK)
+
+/* Old name, for compatibility */
+#define I2C_FUNC_SMBUS_HWPEC_CALC	I2C_FUNC_SMBUS_PEC
+
+/*
+ * Data for SMBus Messages
+ */
+#define I2C_SMBUS_BLOCK_MAX	32	/* As specified in SMBus standard */
+#define I2C_SMBUS_I2C_BLOCK_MAX	32	/* Not specified but we use same structure */
+union i2c_smbus_data {
+	__u8 byte;
+	__u16 word;
+	__u8 block[I2C_SMBUS_BLOCK_MAX + 2]; /* block[0] is used for length */
+	                                            /* and one more for PEC */
+};
+
+/* smbus_access read or write markers */
+#define I2C_SMBUS_READ	1
+#define I2C_SMBUS_WRITE	0
+
+/* SMBus transaction types (size parameter in the above functions)
+   Note: these no longer correspond to the (arbitrary) PIIX4 internal codes! */
+#define I2C_SMBUS_QUICK		    0
+#define I2C_SMBUS_BYTE		    1
+#define I2C_SMBUS_BYTE_DATA	    2
+#define I2C_SMBUS_WORD_DATA	    3
+#define I2C_SMBUS_PROC_CALL	    4
+#define I2C_SMBUS_BLOCK_DATA	    5
+#define I2C_SMBUS_I2C_BLOCK_BROKEN  6
+#define I2C_SMBUS_BLOCK_PROC_CALL   7		/* SMBus 2.0 */
+#define I2C_SMBUS_I2C_BLOCK_DATA    8
+
+
+/* /dev/i2c-X ioctl commands.  The ioctl's parameter is always an
+ * unsigned long, except for:
+ *	- I2C_FUNCS, takes pointer to an unsigned long
+ *	- I2C_RDWR, takes pointer to struct i2c_rdwr_ioctl_data
+ *	- I2C_SMBUS, takes pointer to struct i2c_smbus_ioctl_data
+ */
+#define I2C_RETRIES	0x0701	/* number of times a device address should
+				   be polled when not acknowledging */
+#define I2C_TIMEOUT	0x0702	/* set timeout in units of 10 ms */
+
+/* NOTE: Slave address is 7 or 10 bits, but 10-bit addresses
+ * are NOT supported! (due to code brokenness)
+ */
+#define I2C_SLAVE	0x0703	/* Use this slave address */
+#define I2C_SLAVE_FORCE	0x0706	/* Use this slave address, even if it
+				   is already in use by a driver! */
+#define I2C_TENBIT	0x0704	/* 0 for 7 bit addrs, != 0 for 10 bit */
+
+#define I2C_FUNCS	0x0705	/* Get the adapter functionality mask */
+
+#define I2C_RDWR	0x0707	/* Combined R/W transfer (one STOP only) */
+
+#define I2C_PEC		0x0708	/* != 0 to use PEC with SMBus */
+#define I2C_SMBUS	0x0720	/* SMBus transfer */
+
+
+/* This is the structure as used in the I2C_SMBUS ioctl call */
+struct i2c_smbus_ioctl_data {
+	__u8 read_write;
+	__u8 command;
+	__u32 size;
+	union i2c_smbus_data *data;
+};
+
+/* This is the structure as used in the I2C_RDWR ioctl call */
+struct i2c_rdwr_ioctl_data {
+	struct i2c_msg *msgs;	/* pointers to i2c_msgs */
+	__u32 nmsgs;			/* number of i2c_msgs */
+};
+
+#define  I2C_RDRW_IOCTL_MAX_MSGS	42
+
+
+static inline __s32 i2c_smbus_access(int file, char read_write, __u8 command,
+                                     int size, union i2c_smbus_data *data)
+{
+	struct i2c_smbus_ioctl_data args;
+
+	args.read_write = read_write;
+	args.command = command;
+	args.size = size;
+	args.data = data;
+	return ioctl(file,I2C_SMBUS,&args);
+}
+
+
+static inline __s32 i2c_smbus_write_quick(int file, __u8 value)
+{
+	return i2c_smbus_access(file,value,0,I2C_SMBUS_QUICK,NULL);
+}
+
+static inline __s32 i2c_smbus_read_byte(int file)
+{
+	union i2c_smbus_data data;
+	if (i2c_smbus_access(file,I2C_SMBUS_READ,0,I2C_SMBUS_BYTE,&data))
+		return -1;
+	else
+		return 0x0FF & data.byte;
+}
+
+static inline __s32 i2c_smbus_write_byte(int file, __u8 value)
+{
+	return i2c_smbus_access(file,I2C_SMBUS_WRITE,value,
+	                        I2C_SMBUS_BYTE,NULL);
+}
+
+static inline __s32 i2c_smbus_read_byte_data(int file, __u8 command)
+{
+	union i2c_smbus_data data;
+	if (i2c_smbus_access(file,I2C_SMBUS_READ,command,
+	                     I2C_SMBUS_BYTE_DATA,&data))
+		return -1;
+	else
+		return 0x0FF & data.byte;
+}
+
+static inline __s32 i2c_smbus_write_byte_data(int file, __u8 command,
+                                              __u8 value)
+{
+	union i2c_smbus_data data;
+	data.byte = value;
+	return i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                        I2C_SMBUS_BYTE_DATA, &data);
+}
+
+static inline __s32 i2c_smbus_read_word_data(int file, __u8 command)
+{
+	union i2c_smbus_data data;
+	if (i2c_smbus_access(file,I2C_SMBUS_READ,command,
+	                     I2C_SMBUS_WORD_DATA,&data))
+		return -1;
+	else
+		return 0x0FFFF & data.word;
+}
+
+static inline __s32 i2c_smbus_write_word_data(int file, __u8 command,
+                                              __u16 value)
+{
+	union i2c_smbus_data data;
+	data.word = value;
+	return i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                        I2C_SMBUS_WORD_DATA, &data);
+}
+
+static inline __s32 i2c_smbus_process_call(int file, __u8 command, __u16 value)
+{
+	union i2c_smbus_data data;
+	data.word = value;
+	if (i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                     I2C_SMBUS_PROC_CALL,&data))
+		return -1;
+	else
+		return 0x0FFFF & data.word;
+}
+
+
+/* Returns the number of read bytes */
+static inline __s32 i2c_smbus_read_block_data(int file, __u8 command,
+                                              __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i;
+	if (i2c_smbus_access(file,I2C_SMBUS_READ,command,
+	                     I2C_SMBUS_BLOCK_DATA,&data))
+		return -1;
+	else {
+		for (i = 1; i <= data.block[0]; i++)
+			values[i-1] = data.block[i];
+		return data.block[0];
+	}
+}
+
+static inline __s32 i2c_smbus_write_block_data(int file, __u8 command,
+                                               __u8 length, const __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i;
+	if (length > 32)
+		length = 32;
+	for (i = 1; i <= length; i++)
+		data.block[i] = values[i-1];
+	data.block[0] = length;
+	return i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                        I2C_SMBUS_BLOCK_DATA, &data);
+}
+
+/* Returns the number of read bytes */
+/* Until kernel 2.6.22, the length is hardcoded to 32 bytes. If you
+   ask for less than 32 bytes, your code will only work with kernels
+   2.6.23 and later. */
+static inline __s32 i2c_smbus_read_i2c_block_data(int file, __u8 command,
+                                                  __u8 length, __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i;
+
+	if (length > 32)
+		length = 32;
+	data.block[0] = length;
+	if (i2c_smbus_access(file,I2C_SMBUS_READ,command,
+	                     length == 32 ? I2C_SMBUS_I2C_BLOCK_BROKEN :
+	                      I2C_SMBUS_I2C_BLOCK_DATA,&data))
+		return -1;
+	else {
+		for (i = 1; i <= data.block[0]; i++)
+			values[i-1] = data.block[i];
+		return data.block[0];
+	}
+}
+
+static inline __s32 i2c_smbus_write_i2c_block_data(int file, __u8 command,
+                                                   __u8 length,
+                                                   const __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i;
+	if (length > 32)
+		length = 32;
+	for (i = 1; i <= length; i++)
+		data.block[i] = values[i-1];
+	data.block[0] = length;
+	return i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                        I2C_SMBUS_I2C_BLOCK_BROKEN, &data);
+}
+
+/* Returns the number of read bytes */
+static inline __s32 i2c_smbus_block_process_call(int file, __u8 command,
+                                                 __u8 length, __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i;
+	if (length > 32)
+		length = 32;
+	for (i = 1; i <= length; i++)
+		data.block[i] = values[i-1];
+	data.block[0] = length;
+	if (i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                     I2C_SMBUS_BLOCK_PROC_CALL,&data))
+		return -1;
+	else {
+		for (i = 1; i <= data.block[0]; i++)
+			values[i-1] = data.block[i];
+		return data.block[0];
+	}
+}
+
+
+#endif /* _LINUX_I2C_DEV_H */

--- a/src/motor2927_controller.cpp
+++ b/src/motor2927_controller.cpp
@@ -1,0 +1,56 @@
+/**
+ *  motor2927_controller.cpp
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2018, Gavin Kane
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+#include <ros/ros.h>
+#include "jetbotHardwareInt.h"
+#include <controller_manager/controller_manager.h>
+
+int main(int argc, char ** argv)
+{
+	ros::init(argc, argv, "motor2927_controller");
+
+	jetbotHardwareInt jetbot;
+	controller_manager::ControllerManager cm(&jetbot);
+
+	ros::AsyncSpinner spinner(1);
+	spinner.start();
+
+	// Control Loop
+	ros::Time prev_time = ros::Time::now();
+	ros::Rate rate(50.0);
+
+	while (ros::ok())
+	{
+		const ros::Time  time = ros::Time::now();
+		const ros::Duration period = time - prev_time;
+
+		jetbot.read();
+		cm.update(time, period);
+		jetbot.write();
+
+		rate.sleep();
+	}
+}

--- a/src/pwm.cpp
+++ b/src/pwm.cpp
@@ -1,0 +1,113 @@
+/**
+ *  pwm.cpp
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2018, Tom Clarke
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+#include "pwm.h"
+
+#include <iostream>
+#include <thread>
+#include <chrono>
+
+PWM::PWM (int busAddress, int deviceAddress)
+    : device (busAddress, deviceAddress)
+{
+    if (device.isValid())
+    {
+        //std::cout << "Resetting PCA9685 mode 1 (without sleep) and mode 2";
+        //std::cout << std::endl;
+
+        setAll (0, 0);
+        device.write8 (Registers::kMode2, Bits::kOutDrive);
+        device.write8 (Registers::kMode1, Bits::kAllCall);
+
+        // wait for oscillator
+        std::this_thread::sleep_for (std::chrono::milliseconds (5));
+        int mode = device.read8 (Registers::kMode1);
+        // reset sleep
+        mode = mode & ~Bits::kSleep;
+        device.write8 (Registers::kMode1, mode);
+
+        // wait for oscillator
+        std::this_thread::sleep_for (std::chrono::milliseconds (5));
+    }
+}
+
+void PWM::setFrequency (double frequency)
+{
+    if (device.isValid())
+    {
+        // 25Mhz
+        double preScaleValue = 25000000.0;
+        // to 12-bit
+        preScaleValue /= 4096.0;
+        preScaleValue /= frequency;
+        preScaleValue -= 1.0;
+
+        //std::cout << "Setting PWM frequency to " << frequency << "Hz";
+        //std::cout << std::endl;
+        //std::cout << "Estimated pre-scale: " << preScaleValue << std::endl;
+
+        const int finalPreScale = static_cast<int> (preScaleValue + 0.5);
+        //std::cout << "Final pre-scale: " << finalPreScale << std::endl;
+
+        const int oldMode = 0x00;// = device.read8 (Registers::kMode1);
+        const int newMode = (oldMode & 0x7F) | Bits::kSleep;
+
+        // go to sleep
+        device.write8 (Registers::kMode1, newMode);
+        // set prescale
+        device.write8 (Registers::kPreScale, finalPreScale);
+        // wake up
+        device.write8 (Registers::kMode1, oldMode);
+
+        std::this_thread::sleep_for (std::chrono::milliseconds (5));
+
+        // restart
+        device.write8 (Registers::kMode1, oldMode | Bits::kRestart);
+    }
+}
+
+void PWM::setChannel (int channel, int on, int off)
+{
+    //std::cout << "Set channel " << channel << ", on: " << on << ", off: " << off << std::endl;
+    if (device.isValid())
+    {
+       device.write8 (Registers::kLed0OnL + 4 * channel, on & 0xFF);
+       device.write8 (Registers::kLed0OnH + 4 * channel, on >> 8);
+       device.write8 (Registers::kLed0OffL + 4 * channel, off & 0xFF);
+       device.write8 (Registers::kLed0OffH + 4 * channel, off >> 8);
+    }
+}
+
+void PWM::setAll (int on, int off)
+{
+    if (device.isValid())
+    {
+       device.write8 (Registers::kAllLedOnL, on & 0xFF);
+       device.write8 (Registers::kAllLedOnH, on >> 8);
+       device.write8 (Registers::kAllLedOffL, off & 0xFF);
+       device.write8 (Registers::kAllLedOffH, off >> 8);
+    }
+}

--- a/src/pwm.h
+++ b/src/pwm.h
@@ -1,0 +1,77 @@
+/**
+ *  pwm.h
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2018, Tom Clarke
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+#pragma once
+
+//#include "i2cdevice.h"
+#include "i2cdevice_wrapper.h"
+
+class PWM
+{
+public:
+    // Registers/etc.
+    enum Registers
+    {
+        kMode1       = 0x00,
+        kMode2       = 0x01,
+        kSubAddress1 = 0x02,
+        kSubAddress2 = 0x03,
+        kSubAddress3 = 0x04,
+        kPreScale    = 0xFE,
+        kLed0OnL     = 0x06,
+        kLed0OnH     = 0x07,
+        kLed0OffL    = 0x08,
+        kLed0OffH    = 0x09,
+        kAllLedOnL   = 0xFA,
+        kAllLedOnH   = 0xFB,
+        kAllLedOffL  = 0xFC,
+        kAllLedOffH  = 0xFD,
+    };
+
+    // Bits
+    enum Bits
+    {
+        kRestart     = 0x80,
+        kSleep       = 0x10,
+        kAllCall     = 0x01,
+        kInvert      = 0x10,
+        kOutDrive    = 0x04,
+    };
+
+    PWM (int busAddress, int deviceAddress);
+
+    /** Sets the PWM frequency */
+    void setFrequency (double frequency);
+
+    /** Sets a single PWM channel */
+    void setChannel (int channel, int on, int off);
+
+    /** Sets all the PWM channels */
+    void setAll (int on, int off);
+
+private:
+    i2cdevice_wrapper device;
+};


### PR DESCRIPTION
Pull request creates a differential drive controller, with the motor control inside a hardwareinterfface class using Tom Clarks cpp version of the ADAfruitMotorHat.  It allows /mobile_base_controller/cmd_vel messages to be recieved by jetbot, and robot will be able to provide odom messages back.
Odom is provided through dead reconing, whích for a robot without any sensors on the motors, is the best we can do.  If the robot is moving fast, it works well.  If the robot is trying to move slowly, near the dead-zone of the motor, it is not very accurate.  But working with AMCL it is good enough to maintain a track of its position in a given map.  Best not to run AMCL on the Jetbot itself, but on a separate computer.