### PR TITLE
Support motor driver in SparkFun kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ $ sudo apt-get install python-pip
 # install Adafruit libraries
 $ pip install Adafruit-MotorHAT
 $ pip install Adafruit-SSD1306
+
+# Install SparkFun Python packages
+$ pip install sparkfun-qwiic
 ```
 
 Grant your user access to the i2c bus:

--- a/scripts/jetbot_motors.py
+++ b/scripts/jetbot_motors.py
@@ -2,40 +2,29 @@
 import rospy
 import time
 
-from Adafruit_MotorHAT import Adafruit_MotorHAT
+import qwiic_scmd
 from std_msgs.msg import String
-
-
 
 
 # sets motor speed between [-1.0, 1.0]
 def set_speed(motor_ID, value):
 	max_pwm = 115.0
-	speed = int(min(max(abs(value * max_pwm), 0), max_pwm))
+	#speed = int(min(max(abs(value * max_pwm), 0), max_pwm))
+	speed = int(value * max_pwm)
 
-	if motor_ID == 1:
-		motor = motor_left
-	elif motor_ID == 2:
-		motor = motor_right
+	if motor_ID == 1 or 2:
+		motor_driver.set_drive(motor_ID - 1, 0, speed)
 	else:
 		rospy.logerror('set_speed(%d, %f) -> invalid motor_ID=%d', motor_ID, value, motor_ID)
 		return
-	
-	motor.setSpeed(speed)
-
-	if value > 0:
-		motor.run(Adafruit_MotorHAT.FORWARD)
-	else:
-		motor.run(Adafruit_MotorHAT.BACKWARD)
 
 
 # stops all motors
 def all_stop():
-	motor_left.setSpeed(0)
-	motor_right.setSpeed(0)
+	motor_driver.set_drive(0,0,0)
+	motor_driver.set_drive(1,0,0)
 
-	motor_left.run(Adafruit_MotorHAT.RELEASE)
-	motor_right.run(Adafruit_MotorHAT.RELEASE)
+	motor_driver.disable()
 
 
 # directional commands (degree, speed)
@@ -50,18 +39,23 @@ def on_cmd_raw(msg):
 def on_cmd_str(msg):
 	rospy.loginfo(rospy.get_caller_id() + ' cmd_str=%s', msg.data)
 
+
 	if msg.data.lower() == "left":
 		set_speed(motor_left_ID,  -1.0)
-		set_speed(motor_right_ID,  1.0) 
+		set_speed(motor_right_ID,  1.0)
+		motor_driver.enable()
 	elif msg.data.lower() == "right":
 		set_speed(motor_left_ID,   1.0)
-		set_speed(motor_right_ID, -1.0) 
+		set_speed(motor_right_ID, -1.0)
+		motor_driver.enable()
 	elif msg.data.lower() == "forward":
 		set_speed(motor_left_ID,   1.0)
 		set_speed(motor_right_ID,  1.0)
+		motor_driver.enable()
 	elif msg.data.lower() == "backward":
 		set_speed(motor_left_ID,  -1.0)
 		set_speed(motor_right_ID, -1.0)  
+		motor_driver.enable()
 	elif msg.data.lower() == "stop":
 		all_stop()
 	else:
@@ -72,14 +66,16 @@ def on_cmd_str(msg):
 if __name__ == '__main__':
 
 	# setup motor controller
-	motor_driver = Adafruit_MotorHAT(i2c_bus=1)
+	motor_driver = qwiic_scmd.QwiicScmd()
 
 	motor_left_ID = 1
 	motor_right_ID = 2
 
-	motor_left = motor_driver.getMotor(motor_left_ID)
-	motor_right = motor_driver.getMotor(motor_right_ID)
+	print(motor_left_ID)	
 
+	#motor_left = motor_driver.getMotor(motor_left_ID)
+	#motor_right = motor_driver.getMotor(motor_right_ID)
+	
 	# stop the motors as precaution
 	all_stop()
 
@@ -95,4 +91,3 @@ if __name__ == '__main__':
 
 	# stop motors before exiting
 	all_stop()
-

--- a/scripts/jetbot_motors.py
+++ b/scripts/jetbot_motors.py
@@ -35,6 +35,7 @@ def set_speed(motor_ID, value):
 
 		if motor_ID == 1 or 2:
 			motor_driver.set_drive(motor_ID - 1, 0, speed)
+			motor_driver.enable()
 		else:
 			rospy.logerror('set_speed(%d, %f) -> invalid motor_ID=%d', motor_ID, value, motor_ID)
 			return
@@ -72,19 +73,15 @@ def on_cmd_str(msg):
 	if msg.data.lower() == "left":
 		set_speed(motor_left_ID,  -1.0)
 		set_speed(motor_right_ID,  1.0)
-		motor_driver.enable()
 	elif msg.data.lower() == "right":
 		set_speed(motor_left_ID,   1.0)
 		set_speed(motor_right_ID, -1.0)
-		motor_driver.enable()
 	elif msg.data.lower() == "forward":
 		set_speed(motor_left_ID,   1.0)
 		set_speed(motor_right_ID,  1.0)
-		motor_driver.enable()
 	elif msg.data.lower() == "backward":
 		set_speed(motor_left_ID,  -1.0)
 		set_speed(motor_right_ID, -1.0)  
-		motor_driver.enable()
 	elif msg.data.lower() == "stop":
 		all_stop()
 	else:


### PR DESCRIPTION
Adds support for motor driver in SparkFun kit:
- Add functionality for motor driver in SparkFun kit.
- Add instructions for installing required Python packages

***Note:** OLED display would require Python 3 support; currently, Python 2 utilized.*